### PR TITLE
Fix rendering on form reset

### DIFF
--- a/src/select.component.ts
+++ b/src/select.component.ts
@@ -368,6 +368,7 @@ export class SelectComponent implements ControlValueAccessor, OnInit, OnChanges 
 
         if (typeof value === 'undefined' || value === null) {
             value = [];
+            this.clearSelected();
         }
 
         this.value = value;


### PR DESCRIPTION
When using `form.reset()` the model gets reset but the component isn't re-rendered. With this patch the component will show proper state of the model.