### PR TITLE
Ensure selected options to be an array

### DIFF
--- a/src/option-list.ts
+++ b/src/option-list.ts
@@ -51,6 +51,7 @@ export class OptionList {
 
     set value(v: Array<string>) {
         v = typeof v === 'undefined' || v === null ? [] : v;
+        v = [].concat(v);
 
         this.options.forEach((option) => {
             option.selected = v.indexOf(option.value) > -1;


### PR DESCRIPTION
If option values are not primitives but some complex structures like object, you'll try to do `.indexOf` on something which is not an array.