### PR TITLE
Remove filter div altogether when hidden

### DIFF
--- a/src/select-dropdown.component.html
+++ b/src/select-dropdown.component.html
@@ -2,9 +2,8 @@
     [ngStyle]="{'top.px': top, 'left.px': left, 'width.px': width}">
 
     <div class="filter"
-        *ngIf="!multiple">
+        *ngIf="!multiple && filterEnabled">
         <input
-            *ngIf="filterEnabled"
             #filterInput
             (click)="onSingleFilterClick($event)"
             (input)="onSingleFilterInput($event)"


### PR DESCRIPTION
As filter has padding by default, it shows up when filter is hidden.

<img width="203" alt="Example" src="https://cloud.githubusercontent.com/assets/1634026/22694498/69868de0-ed3f-11e6-9d2a-48a9ae790086.png">
